### PR TITLE
Remove warnings that flood the complilation output

### DIFF
--- a/src/meta_yield/kickstarter.mo
+++ b/src/meta_yield/kickstarter.mo
@@ -89,10 +89,10 @@ module {
   public func get_after_unfreeze_deposits(kickstarter: T.Kickstarter, supporter_id: T.SupporterId): 
     Result.Result<T.Balance, Text> {
     switch( assert_funds_must_be_unfreezed(kickstarter) ) {
-      case( _ ) {};
       case( #ok(false) ) {
         return #err("Price at unfreeze is not defined. Please unfreeze kickstarter funds with fn: unfreeze_kickstarter_funds!")
       };
+      case( _ ) {};
     };
 
     let winner_goal_id = switch (kickstarter.winner_goal_id) {

--- a/src/meta_yield/main.mo
+++ b/src/meta_yield/main.mo
@@ -1304,11 +1304,11 @@ mod tests {
     };
 
     switch icp_receipt {
-      case ( #err(e) ) {
-        return #err("Transfer failure: " # debug_show(e));
-      };
       case (#Ok(r))  {
         Debug.print("RECEPIT: " # Nat.toText(r));
+      };
+      case ( #Err(e) ) {
+        return #err("Transfer failure: " # debug_show(e));
       };
     };
 
@@ -1662,10 +1662,10 @@ mod tests {
       case(?true) {
           
         switch( K.assert_funds_must_be_unfreezed(kickstarter) ) {
-          case( _ ) {};
           case( #ok(false) ) {
             return #err("Price at unfreeze is not defined. Please unfreeze kickstarter funds with fn: unfreeze_kickstarter_funds!")
           };
+          case( _ ) {};
         };
 
         let test = internal_supporter_withdraw_after_unfreeze(


### PR DESCRIPTION
Removed most of the warnings from the compilation output.
There were some warnings left that need a more thorough refactor,
si this were left for a future patch.